### PR TITLE
Pass eval results to generate_eval_report to avoid redundant calculations

### DIFF
--- a/agents/3-llm-loop/functions.py
+++ b/agents/3-llm-loop/functions.py
@@ -114,7 +114,7 @@ def run_all_evals(text, word_count_min=300, word_count_max=800, client_focus_min
     
     return results
 
-def generate_eval_report(profile_text: str) -> str:
+def generate_eval_report(profile_text: str, results: dict) -> str:
     """
     Generates a markdown-formatted prompt for an LLM to revise an Upwork profile,
     with explicit strategies for word count and readability improvements.
@@ -126,8 +126,6 @@ def generate_eval_report(profile_text: str) -> str:
         str: A markdown-formatted evaluation report and rewrite instructions
     """
     status_emoji = {True: "✅ Passed", False: "❌ Failed"}
-
-    results = run_all_evals(profile_text)
 
     notes = {
         "word_count": {

--- a/agents/3-llm-loop/llm-loop-copywriter.ipynb
+++ b/agents/3-llm-loop/llm-loop-copywriter.ipynb
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "c3937b9f-7fe7-41d4-8ac2-1a0e4582cafe",
    "metadata": {},
    "outputs": [
@@ -234,7 +234,7 @@
     "    print(results)\n",
     "\n",
     "    # craft new prompt with feedback\n",
-    "    prompt = generate_eval_report(new_profile)\n",
+    "    prompt = generate_eval_report(new_profile, results)\n",
     "\n",
     "    # check if all tests passed\n",
     "    all_passed = all(results.values())\n",


### PR DESCRIPTION
 Improves efficiency and avoids repeating evaluation logic.

Changes:
-     Updated generate_eval_report to accept eval results as input
-     Refactored calling code accordingly